### PR TITLE
Implement ArrowArray for Date64Array

### DIFF
--- a/arrow_convert/src/deserialize/mod.rs
+++ b/arrow_convert/src/deserialize/mod.rs
@@ -383,6 +383,7 @@ impl_arrow_array!(ListArray);
 impl_arrow_array!(LargeListArray);
 impl_arrow_array!(FixedSizeListArray);
 impl_arrow_array!(Date32Array);
+impl_arrow_array!(Date64Array);
 impl_arrow_array!(TimestampNanosecondArray);
 
 /// Top-level API to deserialize from Arrow


### PR DESCRIPTION
Hey @Swoorup just figured out another small thing, a missing implementation of ArrayType. Without this, i can't implement a custom type wrapper myself to deserialize `Date64`