### PR TITLE
Add support for field renaming

### DIFF
--- a/arrow_convert/tests/complex_example.rs
+++ b/arrow_convert/tests/complex_example.rs
@@ -34,6 +34,7 @@ pub struct Root {
     // custom type
     custom: CustomType,
     // custom optional type
+    #[arrow_field(name = "cullable_nustom")]
     nullable_custom: Option<CustomType>,
     // vec custom type
     custom_list: Vec<CustomType>,
@@ -42,7 +43,7 @@ pub struct Root {
     // int 32 array
     int32_array: Vec<i32>,
     // large binary
-    #[arrow_field(type = "arrow_convert::field::LargeBinary")]
+    #[arrow_field(type = "arrow_convert::field::LargeBinary", name = "barge_linary")]
     large_binary: Vec<u8>,
     // fixed size binary
     #[arrow_field(type = "arrow_convert::field::FixedSizeBinary<3>")]
@@ -228,6 +229,12 @@ fn test_round_trip() -> arrow::error::Result<()> {
     let values = struct_array.columns();
     assert_eq!(values.len(), 23);
     assert_eq!(struct_array.len(), 2);
+
+    let names = struct_array.column_names();
+    assert!(!names.iter().any(|x| *x == "nullable_custom"));
+    assert!(names.iter().any(|x| *x == "cullable_nustom"));
+    assert!(!names.iter().any(|x| *x == "large_binary"));
+    assert!(names.iter().any(|x| *x == "barge_linary"));
 
     // can iterate one struct at a time without collecting
     for _i in arrow_array_deserialize_iterator::<Root>(array.borrow())? {

--- a/arrow_convert/tests/ui/struct_no_fields.stderr
+++ b/arrow_convert/tests/ui/struct_no_fields.stderr
@@ -1,4 +1,4 @@
-error: Expected struct to have more than one field
+error: Expected struct to have at least one field
  --> tests/ui/struct_no_fields.rs:4:8
   |
 4 | struct S {}

--- a/arrow_convert_derive/src/attr.rs
+++ b/arrow_convert_derive/src/attr.rs
@@ -1,15 +1,16 @@
 use proc_macro_error::{abort, ResultExt};
-use syn::{Lit, Meta, MetaNameValue};
 use syn::spanned::Spanned;
+use syn::{Lit, Meta, MetaNameValue};
 
 pub const ARROW_FIELD: &'static str = "arrow_field";
 pub const FIELD_TYPE: &'static str = "type";
+pub const FIELD_NAME: &'static str = "name";
 pub const UNION_MODE: &'static str = "mode";
 
 pub fn field_type(field: &syn::Field) -> syn::Type {
     for attr in &field.attrs {
         if let Ok(meta) = attr.parse_meta() {
-            if meta.path().is_ident(ARROW_FIELD) { 
+            if meta.path().is_ident(ARROW_FIELD) {
                 if let Meta::List(list) = meta {
                     for nested in list.nested {
                         if let syn::NestedMeta::Meta(meta) = nested {
@@ -20,9 +21,11 @@ pub fn field_type(field: &syn::Field) -> syn::Type {
                                     ..
                                 }) => {
                                     if path.is_ident(FIELD_TYPE) {
-                                        return syn::parse_str(&string.value()).unwrap_or_abort()
+                                        return syn::parse_str(&string.value()).unwrap_or_abort();
+                                    } else if path.is_ident(FIELD_NAME) {
+                                        return syn::parse_str(&string.value()).unwrap_or_abort();
                                     }
-                                },
+                                }
                                 _ => {
                                     abort!(meta.span(), "Unexpected attribute");
                                 }
@@ -40,7 +43,7 @@ pub fn field_type(field: &syn::Field) -> syn::Type {
 pub fn union_type(input: &syn::DeriveInput) -> bool {
     for attr in &input.attrs {
         if let Ok(meta) = attr.parse_meta() {
-            if meta.path().is_ident(ARROW_FIELD) { 
+            if meta.path().is_ident(ARROW_FIELD) {
                 if let Meta::List(list) = meta {
                     for nested in list.nested {
                         if let syn::NestedMeta::Meta(meta) = nested {
@@ -52,12 +55,18 @@ pub fn union_type(input: &syn::DeriveInput) -> bool {
                                 }) => {
                                     if path.is_ident(UNION_MODE) {
                                         match string.value().as_ref() {
-                                            "sparse" => { return false; },
-                                            "dense" => { return true; },
-                                            _ => { abort!(path.span(), "Unexpected value for mode") }
+                                            "sparse" => {
+                                                return false;
+                                            }
+                                            "dense" => {
+                                                return true;
+                                            }
+                                            _ => {
+                                                abort!(path.span(), "Unexpected value for mode")
+                                            }
                                         }
                                     }
-                                },
+                                }
                                 _ => {
                                     abort!(meta.span(), "Unexpected attribute");
                                 }
@@ -71,3 +80,4 @@ pub fn union_type(input: &syn::DeriveInput) -> bool {
 
     abort!(input.span(), "Missing mode attribute for enum");
 }
+

--- a/arrow_convert_derive/src/derive_enum.rs
+++ b/arrow_convert_derive/src/derive_enum.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a DeriveEnum> for Common<'a> {
         if variant_names.is_empty() {
             abort!(
                 original_name.span(),
-                "Expected enum to have more than one field"
+                "Expected enum to have at least one field"
             );
         }
 

--- a/arrow_convert_derive/src/derive_struct.rs
+++ b/arrow_convert_derive/src/derive_struct.rs
@@ -22,6 +22,12 @@ impl<'a> From<&'a DeriveStruct> for Common<'a> {
 
         let (skipped_fields, fields): (Vec<_>, Vec<_>) =
             input.fields.iter().partition(|field| field.skip);
+        if fields.is_empty() {
+            abort!(
+                original_name.span(),
+                "Expected struct to have at least one field"
+            );
+        }
 
         let field_members = fields
             .iter()
@@ -57,13 +63,6 @@ impl<'a> From<&'a DeriveStruct> for Common<'a> {
                     .map_or_else(|| syn::Member::Unnamed(id.into()), syn::Member::Named)
             })
             .collect::<Vec<_>>();
-
-        if field_members.is_empty() {
-            abort!(
-                original_name.span(),
-                "Expected struct to have more than one field"
-            );
-        }
 
         let field_indices = field_members
             .iter()

--- a/arrow_convert_derive/src/derive_struct.rs
+++ b/arrow_convert_derive/src/derive_struct.rs
@@ -13,6 +13,7 @@ struct Common<'a> {
     skipped_field_names: Vec<syn::Member>,
     field_indices: Vec<syn::LitInt>,
     field_types: Vec<&'a syn::Type>,
+    field_names: Vec<String>,
 }
 
 impl<'a> From<&'a DeriveStruct> for Common<'a> {
@@ -82,6 +83,18 @@ impl<'a> From<&'a DeriveStruct> for Common<'a> {
             })
             .collect::<Vec<&syn::Type>>();
 
+        let field_names = fields
+            .iter()
+            .enumerate()
+            .map(
+                |(id, field)| match (field.field_name.as_ref(), field.syn.ident.as_ref()) {
+                    (Some(name), _) => name.to_owned(), // override enabled
+                    (_, Some(ident)) => format_ident!("{}", ident).to_string(), // no override, named field
+                    (_, None) => format!("field_{id}"), // no override, unnamed field
+                },
+            )
+            .collect::<Vec<_>>();
+
         Self {
             original_name,
             visibility,
@@ -90,6 +103,7 @@ impl<'a> From<&'a DeriveStruct> for Common<'a> {
             skipped_field_names,
             field_indices,
             field_types,
+            field_names,
         }
     }
 }
@@ -97,9 +111,8 @@ impl<'a> From<&'a DeriveStruct> for Common<'a> {
 pub fn expand_field(input: DeriveStruct) -> TokenStream {
     let Common {
         original_name,
-        field_members,
-        //field_names_str,
         field_types,
+        field_names,
         ..
     } = (&input).into();
 
@@ -112,14 +125,10 @@ pub fn expand_field(input: DeriveStruct) -> TokenStream {
                 <#ty as arrow_convert::field::ArrowField>::data_type()
             )
         } else {
-            let field_names = field_members.iter().map(|field| match field {
-                syn::Member::Named(ident) => format_ident!("{}", ident),
-                syn::Member::Unnamed(index) => format_ident!("field_{}", index),
-            });
             quote!(arrow::datatypes::DataType::Struct(
                 arrow::datatypes::Fields::from(vec![
                     #(
-                        <#field_types as arrow_convert::field::ArrowField>::field(stringify!(#field_names)),
+                        <#field_types as arrow_convert::field::ArrowField>::field(#field_names),
                     )*
                 ])
             ))
@@ -143,13 +152,11 @@ pub fn expand_serialize(input: DeriveStruct) -> TokenStream {
     let Common {
         original_name,
         visibility,
-        field_members: field_names,
+        field_members,
         field_idents,
         field_types,
         ..
     } = (&input).into();
-
-    let first_field = &field_names[0];
 
     let mutable_array_name = &input.common.mutable_array_name();
     let mutable_field_array_types = field_types
@@ -206,7 +213,7 @@ pub fn expand_serialize(input: DeriveStruct) -> TokenStream {
                     Some(i) =>  {
                         let i = i.borrow() as &#original_name;
                         #(
-                            <#field_types as arrow_convert::serialize::ArrowSerialize>::arrow_serialize(i.#field_names.borrow(), &mut self.#field_idents)?;
+                            <#field_types as arrow_convert::serialize::ArrowSerialize>::arrow_serialize(i.#field_members.borrow(), &mut self.#field_idents)?;
                         )*;
                         match &mut self.validity {
                             Some(validity) => validity.append(true),
@@ -320,6 +327,7 @@ pub fn expand_serialize(input: DeriveStruct) -> TokenStream {
     // Special case for single-field (tuple) structs.
     if input.fields.len() == 1 && input.is_transparent {
         let first_type = &field_types[0];
+        let first_field = &field_members[0];
         // Everything delegates to first field.
         quote! {
             impl arrow_convert::serialize::ArrowSerialize for #original_name {
@@ -367,7 +375,7 @@ pub fn expand_deserialize(input: DeriveStruct) -> TokenStream {
     let Common {
         original_name,
         visibility,
-        field_members: field_names,
+        field_members,
         field_idents,
         skipped_field_names,
         field_indices,
@@ -377,7 +385,7 @@ pub fn expand_deserialize(input: DeriveStruct) -> TokenStream {
 
     let array_name = &input.common.array_name();
     let iterator_name = &input.common.iterator_name();
-    let is_tuple_struct = matches!(field_names[0], syn::Member::Unnamed(_));
+    let is_tuple_struct = matches!(field_members[0], syn::Member::Unnamed(_));
 
     let array_decl = quote! {
         #visibility struct #array_name
@@ -442,7 +450,7 @@ pub fn expand_deserialize(input: DeriveStruct) -> TokenStream {
     } else {
         syn::parse_quote! {
             #original_name {
-                #(#field_names: <#field_types as arrow_convert::deserialize::ArrowDeserialize>::arrow_deserialize_internal(#field_idents),)*
+                #(#field_members: <#field_types as arrow_convert::deserialize::ArrowDeserialize>::arrow_deserialize_internal(#field_idents),)*
                 #(#skipped_field_names: std::default::Default::default(),)*
             }
         }
@@ -492,7 +500,7 @@ pub fn expand_deserialize(input: DeriveStruct) -> TokenStream {
         let deser_body_mapper = if is_tuple_struct {
             quote! { #original_name }
         } else {
-            let first_name = &field_names[0];
+            let first_name = &field_members[0];
             quote! { |v| #original_name { #first_name: v } }
         };
 


### PR DESCRIPTION
This adds initial support for `#[arrow_field(name = "whatever")]`.

As a next step, I think it would also be nice to have serde-style container-level auto-renaming, e.g. snake-case naming for all fields (note also that some arrow/parquet column names may not be represented as non-raw rust identifiers at all, so it may be required in some cases).