### PR TITLE
Add ArrowArray impl for more timestamp types

### DIFF
--- a/arrow_convert/src/deserialize/mod.rs
+++ b/arrow_convert/src/deserialize/mod.rs
@@ -363,6 +363,9 @@ impl_arrow_array!(LargeListArray);
 impl_arrow_array!(FixedSizeListArray);
 impl_arrow_array!(Date32Array);
 impl_arrow_array!(Date64Array);
+impl_arrow_array!(TimestampSecondArray);
+impl_arrow_array!(TimestampMillisecondArray);
+impl_arrow_array!(TimestampMicrosecondArray);
 impl_arrow_array!(TimestampNanosecondArray);
 
 /// Top-level API to deserialize from Arrow


### PR DESCRIPTION
This avoids end-users having to create newtypes to work with timestamp arrays that aren't nanosecond