### PR TITLE
chore: update to arrow-rs 59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,21 +8,21 @@ authors = [
   "Jorge Leitao <jorgecarleitao@gmail.com>",
   "Chandra Penke <chandrapenke@gmail.com>",
 ]
-version = "0.11.4"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 keywords = ["Arrow", "arrow"]
 repository = "https://github.com/Swoorup/arrow-convert"
 
 [workspace.dependencies]
-arrow_convert = { path = "arrow_convert", version = "0.11.4" }
-arrow_convert_derive = { path = "arrow_convert_derive", version = "0.11.4" }
+arrow_convert = { path = "arrow_convert" }
+arrow_convert_derive = { path = "arrow_convert_derive" }
 
-arrow = { version = "57", default-features = false }
-arrow-array = { version = "57" }
-arrow-buffer = { version = "57" }
-arrow-data = { version = "57" }
-arrow-schema = { version = "57" }
+arrow = { version = "59", default-features = false }
+arrow-array = { version = "59" }
+arrow-buffer = { version = "59" }
+arrow-data = { version = "59" }
+arrow-schema = { version = "59" }
 chrono = { version = "0.4", default-features = false }
 criterion = "0.7"
 err-derive = "0.3"

--- a/arrow_convert_derive/src/derive_enum.rs
+++ b/arrow_convert_derive/src/derive_enum.rs
@@ -84,25 +84,17 @@ pub fn expand_field(input: DeriveEnum) -> TokenStream {
         ..
     } = (&input).into();
 
-    let num_variants = syn::LitInt::new(
-        &format!("{}", variant_types.len()),
-        proc_macro2::Span::call_site(),
-    );
-
     quote! {
         impl arrow_convert::field::ArrowField for #original_name {
             type Type = Self;
 
             fn data_type() -> arrow::datatypes::DataType {
                 arrow::datatypes::DataType::Union(
-                    arrow::datatypes::UnionFields::new(
-                      0..#num_variants, // basically union tag id or here called type_id
-                      vec![
-                          #(
-                              <#variant_types as arrow_convert::field::ArrowField>::field(#variant_names_str),
-                          )*
-                      ]
-                    ),
+                    arrow::datatypes::UnionFields::from_fields(vec![
+                        #(
+                            <#variant_types as arrow_convert::field::ArrowField>::field(#variant_names_str),
+                        )*
+                    ]),
                     #union_type,
                 )
             }


### PR DESCRIPTION
## Summary

Bump `arrow-convert` to support **arrow-rs 59** (from `main`).

- Workspace `arrow` / `arrow-array` / `arrow-buffer` / `arrow-data` / `arrow-schema`: **57 → 59**
- Crate version: **0.11.4 → 0.12.0**
- `UnionFields::new` removed in arrow-schema 59 → `from_fields` (same sequential type ids as `0..n`)
